### PR TITLE
replace slashes to underscore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2.1
+
+jobs:
+  run-static-analysis:
+    parameters:
+      version:
+        type: string
+    docker:
+      - image: circleci/golang:<< parameters.version >>
+        environment:
+          GO111MODULE: "on"
+          # work around for recent circle CI breaking change
+          # Error: "Error response from daemon: client version 1.39 is too new. Maximum supported API version is 1.38"
+          DOCKER_API_VERSION: "1.38"
+    # 2CPU / 4GB RAM
+    resource_class: medium
+    steps:
+
+      - checkout
+
+      - restore_cache:
+          keys:
+            - go-<< parameters.version >>-{{ checksum "go.sum" }}-{{ checksum "Makefile" }}
+
+      - run: make bootstrap
+
+      - save_cache:
+          key: go-<< parameters.version >>-{{ checksum "go.sum" }}-{{ checksum "Makefile" }}
+          paths:
+            - "/go/pkg/mod"
+            - ".tmp"
+
+      - run:
+          name: run static analysis
+          command: make lint
+
+workflows:
+  "Static Analysis":
+    jobs:
+      - run-static-analysis:
+          name: "Static Analysis"
+          version: "latest"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,56 @@
+linters-settings:
+  funlen:
+    lines: 65
+linters:
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+# do not enable...
+#    - gochecknoglobals
+#    - gochecknoinits    # this is too aggressive
+#    - godot
+#    - godox
+#    - goerr113
+#    - gomnd       # this is too aggressive
+#    - interfacer  # this is a good idea, but is no longer supported and is prone to false positives
+#    - lll         # without a way to specify per-line exception cases, this is not usable
+#    - maligned    # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
+#    - nestif
+#    - testpackage
+#    - wsl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+TEMPDIR = ./.tmp
+LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --config .golangci.yaml
+BOLD := $(shell tput -T linux bold)
+PURPLE := $(shell tput -T linux setaf 5)
+GREEN := $(shell tput -T linux setaf 2)
+CYAN := $(shell tput -T linux setaf 6)
+RED := $(shell tput -T linux setaf 1)
+RESET := $(shell tput -T linux sgr0)
+TITLE := $(BOLD)$(PURPLE)
+SUCCESS := $(BOLD)$(GREEN)
+
+ifeq "$(strip $(VERSION))" ""
+ override VERSION = $(shell git describe --always --tags --dirty)
+endif
+
+## Variable assertions
+
+ifndef TEMPDIR
+	$(error TEMPDIR is not set)
+endif
+
+define title
+    @printf '$(TITLE)$(1)$(RESET)\n'
+endef
+
+.PHONY: all
+all: lint ## Run all checks (linting for now)
+	@printf '$(SUCCESS)All checks pass!$(RESET)\n'
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "$(BOLD)$(CYAN)%-25s$(RESET)%s\n", $$1, $$2}'
+
+.PHONY: boostrap
+bootstrap: ## Download and install all go dependencies (+ prep tooling in the ./tmp dir)
+	$(call title,Boostrapping dependencies)
+	@pwd
+	# prep temp dirs
+	mkdir -p $(TEMPDIR)
+	# install go dependencies
+	go mod download
+	# install utilities
+	[ -f "$(TEMPDIR)/golangci" ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.26.0
+	[ -f "$(TEMPDIR)/bouncer" ] || curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.2.0
+
+.PHONY: static-analysis
+static-analysis: lint check-licenses
+
+.PHONY: lint
+lint: ## Run gofmt + golangci lint checks
+	$(call title,Running linters)
+	# ensure there are no go fmt differences
+	@printf "files with gofmt issues: [$(shell gofmt -l -s .)]\n"
+	@test -z "$(shell gofmt -l -s .)"
+
+	# run all golangci-lint rules
+	$(LINTCMD)
+
+	# go tooling does not play well with certain filename characters, ensure the common cases don't result in future "go get" failures
+	$(eval MALFORMED_FILENAMES := $(shell find . | grep -e ':'))
+	@bash -c "[[ '$(MALFORMED_FILENAMES)' == '' ]] || (printf '\nfound unsupported filename characters:\n$(MALFORMED_FILENAMES)\n\n' && false)"
+
+
+.PHONY: lint-fix
+lint-fix: ## Auto-format all source code + run golangci lint fixers
+	$(call title,Running lint fixers)
+	gofmt -w -s .
+	$(LINTCMD) --fix
+
+.PHONY: check-licenses
+check-licenses:
+	$(TEMPDIR)/bouncer check

--- a/golden_files.go
+++ b/golden_files.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/image"
@@ -61,8 +62,10 @@ func copyFile(t *testing.T, src, dst string) {
 
 func GetGoldenFilePath(t *testing.T) string {
 	t.Helper()
-
-	return path.Join(goldenFileDirPath, t.Name()+goldenFileExt)
+	// When using table-driven-tests, the `t.Name()` results in a string with slashes
+	// which makes it impossible to reference in a filesystem, producing a "No such file or directory"
+	filename := strings.ReplaceAll(t.Name(), "/", "_")
+	return path.Join(goldenFileDirPath, filename+goldenFileExt)
 }
 
 func UpdateGoldenFileContents(t *testing.T, contents []byte) {

--- a/image_fixtures.go
+++ b/image_fixtures.go
@@ -68,7 +68,8 @@ func skopeoCopyDockerArchiveToPath(t *testing.T, dockerArchivePath, destination 
 		t.Fatalf("cannot find skopeo executable")
 	}
 
-	cmd := exec.Command("skopeo", "copy", fmt.Sprintf("docker-archive:%s", dockerArchivePath), destination)
+	archive := fmt.Sprintf("docker-archive:%s", dockerArchivePath)
+	cmd := exec.Command("skopeo", "copy", archive, destination)
 	cmd.Env = os.Environ()
 
 	cmd.Stdout = os.Stdout

--- a/image_fixtures.go
+++ b/image_fixtures.go
@@ -211,15 +211,14 @@ func hasImage(t *testing.T, imageName string) bool {
 	cmd := exec.Command("docker", "image", "inspect", imageName)
 	cmd.Env = os.Environ()
 	err := cmd.Run()
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func buildImage(t *testing.T, contextDir, name, tag string) error {
 	t.Helper()
-	cmd := exec.Command("docker", "build", "-t", name+":"+tag, "-t", name+":latest", ".")
+	fullTag := fmt.Sprintf("%s:%s", name, tag)
+	latestTag := fmt.Sprintf("%s:latest", name)
+	cmd := exec.Command("docker", "build", "-t", fullTag, "-t", latestTag, ".")
 	cmd.Env = os.Environ()
 	cmd.Dir = contextDir
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Table driven tests will use slashes when calling `t.Name()` which makes it impossible to use them as-is for golden images on disk.

This change allows using golden images in table driven tests without affecting existing tests

There weren't any CI hooks, so I added them, including a `Makefile`. Only linting for now though - which is why this PR includes lint fixes